### PR TITLE
rpitemp.sh: more idiomatic Bash ∞ loop

### DIFF
--- a/rpitemp.sh
+++ b/rpitemp.sh
@@ -1,4 +1,4 @@
-while [ 1 -lt 2 ]
+while :
 	do
 		clear
 		vcgencmd measure_temp


### PR DESCRIPTION
`:` in Bash is the shortest truthy value, and is used in idiomatic ∞ loops.